### PR TITLE
Add folder implementation and tests

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -7,5 +7,8 @@ org.gradle.welcome=never
 org.gradle.parallel=true
 org.gradle.caching=true
 
+# gimme moree
+org.gradle.jvmargs=-Xmx6G -Dkotlin.daemon.jvm.options\="-Xmx6G"
+
 # android stuff
 android.useAndroidX=true

--- a/kstore/api/android/kstore.api
+++ b/kstore/api/android/kstore.api
@@ -5,6 +5,16 @@ public final class io/github/xxfast/kstore/BuildConfig {
 	public fun <init> ()V
 }
 
+public final class io/github/xxfast/kstore/KFolder {
+	public fun <init> (Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function1;)V
+	public final fun add (Ljava/lang/Object;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun delete (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun get (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun getIndexUpdates ()Lkotlinx/coroutines/flow/Flow;
+	public final fun getIndexes ()Ljava/util/Set;
+	public final fun remove (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
 public final class io/github/xxfast/kstore/KListStoreKt {
 	public static final fun get (Lio/github/xxfast/kstore/KStore;ILkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static final fun getOrEmpty (Lio/github/xxfast/kstore/KStore;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;

--- a/kstore/api/desktop/kstore.api
+++ b/kstore/api/desktop/kstore.api
@@ -1,3 +1,13 @@
+public final class io/github/xxfast/kstore/KFolder {
+	public fun <init> (Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function1;)V
+	public final fun add (Ljava/lang/Object;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun delete (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun get (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun getIndexUpdates ()Lkotlinx/coroutines/flow/Flow;
+	public final fun getIndexes ()Ljava/util/Set;
+	public final fun remove (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
 public final class io/github/xxfast/kstore/KListStoreKt {
 	public static final fun get (Lio/github/xxfast/kstore/KStore;ILkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static final fun getOrEmpty (Lio/github/xxfast/kstore/KStore;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;

--- a/kstore/src/commonMain/kotlin/io/github/xxfast/kstore/KFolder.kt
+++ b/kstore/src/commonMain/kotlin/io/github/xxfast/kstore/KFolder.kt
@@ -1,0 +1,74 @@
+@file:OptIn(ExperimentalSerializationApi::class)
+
+package io.github.xxfast.kstore
+
+import io.github.xxfast.kstore.utils.FILE_SYSTEM
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import okio.BufferedSink
+import okio.BufferedSource
+import okio.Path
+import okio.Path.Companion.toPath
+import okio.buffer
+import okio.use
+import kotlinx.serialization.json.okio.decodeFromBufferedSource as decode
+import kotlinx.serialization.json.okio.encodeToBufferedSink as encode
+
+inline fun <reified T : @Serializable Any> folderOf(
+  folderPath: String,
+  serializer: Json = Json,
+  noinline indexWith: (T) -> String,
+): KFolder<T> {
+  val encoder: (BufferedSink, T?) -> Unit = { sink: BufferedSink, value: T? -> sink.use { serializer.encode(value, it) } }
+  val decoder: (BufferedSource) -> T? = { source: BufferedSource -> serializer.decode(source) }
+  return KFolder(folderPath, indexWith, encoder, decoder)
+}
+
+class KFolder<T : @Serializable Any>(
+  private val folderPath: String,
+  private val indexWith: (T) -> String,
+  private val encoder: (BufferedSink, T?) -> Unit,
+  private val decoder: (BufferedSource) -> T?
+) {
+  private val lock: Mutex = Mutex()
+  private val stateFlow: MutableStateFlow<Set<String>> = MutableStateFlow(indexes)
+
+  val indexes: Set<String> get() {
+    if(!FILE_SYSTEM.exists(folderPath.toPath())) return emptySet()
+    return FILE_SYSTEM.list(folderPath.toPath()).map { it.name }.toSet()
+  }
+
+  val indexUpdates: Flow<Set<String>> = stateFlow
+
+  suspend fun get(index: String): T? = lock.withLock {
+    val path: Path = "$folderPath/$index".toPath()
+    if(!FILE_SYSTEM.exists(path)) return@withLock null
+    decoder(FILE_SYSTEM.source(path).buffer())
+  }
+
+  suspend fun add(value: T) {
+    if(!FILE_SYSTEM.exists(folderPath.toPath()))
+      FILE_SYSTEM.createDirectory(folderPath.toPath(), false)
+
+    val index: String = indexWith(value)
+    lock.withLock { encoder(FILE_SYSTEM.sink("$folderPath/$index".toPath()).buffer(), value) }
+    stateFlow.emit(indexes)
+  }
+
+  suspend fun remove(index: String) {
+    if(!FILE_SYSTEM.exists(folderPath.toPath())) return
+    lock.withLock { FILE_SYSTEM.delete("$folderPath/$index".toPath()) }
+    stateFlow.emit(indexes)
+  }
+
+  suspend fun delete(){
+    if(!FILE_SYSTEM.exists(folderPath.toPath())) return
+    lock.withLock { FILE_SYSTEM.deleteRecursively(folderPath.toPath()) }
+    stateFlow.emit(indexes)
+  }
+}

--- a/kstore/src/commonTest/kotlin/io/github/xxfast/kstore/KFolderTests.kt
+++ b/kstore/src/commonTest/kotlin/io/github/xxfast/kstore/KFolderTests.kt
@@ -1,0 +1,101 @@
+@file:OptIn(ExperimentalCoroutinesApi::class)
+
+package io.github.xxfast.kstore
+
+import app.cash.turbine.test
+import io.github.xxfast.kstore.utils.FILE_SYSTEM
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import okio.Path.Companion.toPath
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class KFolderTests {
+  private val folderPath: String = "test"
+  private val folder: KFolder<Cat> = folderOf(folderPath) { cat -> cat.json }
+
+  private val Cat.json: String get() = "${name}.json"
+
+  @AfterTest
+  fun shutdown() {
+    FILE_SYSTEM.deleteRecursively(folderPath.toPath(), false)
+  }
+
+  @Test
+  fun testEmptyIndex() = runTest {
+    val expect: Set<String> = emptySet()
+    val actual: Set<String> = folder.indexes
+    assertEquals(expect, actual)
+  }
+
+  @Test
+  fun testIndex() = runTest {
+    folder.add(MYLO)
+    folder.add(OREO)
+    val expect: Set<String> = setOf(MYLO.json, OREO.json)
+    val actual: Set<String> = folder.indexes
+    assertEquals(expect, actual)
+  }
+
+  @Test
+  fun testGet() = runTest {
+    folder.add(MYLO)
+    val expect: Cat = MYLO
+    val actual: Cat? = folder.get(MYLO.json)
+    assertEquals(expect, actual)
+  }
+
+  @Test
+  fun testAdd() = runTest {
+    folder.add(OREO)
+    folder.add(MYLO)
+    val expect: Set<String> = setOf(OREO.json, MYLO.json)
+    val actual: Set<String> = folder.indexes
+    assertEquals(expect, actual)
+  }
+
+  @Test
+  fun testRemove() = runTest {
+    folder.add(MYLO)
+    folder.add(OREO)
+    folder.remove(OREO.json)
+    val expect: Set<String> = setOf(MYLO.json)
+    val actual: Set<String> = folder.indexes
+    assertEquals(expect, actual)
+  }
+
+  @Test
+  fun testDelete() = runTest {
+    folder.add(MYLO)
+    folder.add(OREO)
+    folder.delete()
+    val expect: Set<String> = emptySet()
+    val actual: Set<String> = folder.indexes
+    assertEquals(expect, actual)
+  }
+
+  @Test
+  fun testIndexUpdates() = runTest {
+    folder.indexUpdates.test {
+      val expectEmptyUpdate: Set<String> = emptySet()
+      val actualEmptyUpdate: Set<String> = awaitItem()
+      assertEquals(expectEmptyUpdate, actualEmptyUpdate)
+
+      folder.add(MYLO)
+      val expectJustMyloUpdate: Set<String> = setOf(MYLO.json)
+      val actualJustMyloUpdate: Set<String> = awaitItem()
+      assertEquals(expectJustMyloUpdate, actualJustMyloUpdate)
+
+      folder.add(OREO)
+      val expectMyloAndOreoUpdate: Set<String> = setOf(MYLO.json, OREO.json)
+      val actualMyloAndOreoUpdate: Set<String> = awaitItem()
+      assertEquals(expectMyloAndOreoUpdate, actualMyloAndOreoUpdate)
+
+      folder.delete()
+      val expectDeletedUpdate: Set<String> = emptySet()
+      val actualDeletedUpdate: Set<String> = awaitItem()
+      assertEquals(expectDeletedUpdate, actualDeletedUpdate)
+    }
+  }
+}


### PR DESCRIPTION
`KFolder` lets you manage folders similar to how `KStore` lets you manage files. Useful when you have lots of data and when you need random access with a given index 