### PR TITLE
Add cached delegate to get cached value synchronously

### DIFF
--- a/kstore/api/android/kstore.api
+++ b/kstore/api/android/kstore.api
@@ -16,6 +16,10 @@ public final class io/github/xxfast/kstore/KStore {
 	public final fun update (Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
+public final class io/github/xxfast/kstore/extensions/KCachedStoreKt {
+	public static final fun getCached (Lio/github/xxfast/kstore/KStore;)Ljava/lang/Object;
+}
+
 public final class io/github/xxfast/kstore/extensions/KListStoreKt {
 	public static final fun get (Lio/github/xxfast/kstore/KStore;ILkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static final fun getOrEmpty (Lio/github/xxfast/kstore/KStore;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;

--- a/kstore/api/desktop/kstore.api
+++ b/kstore/api/desktop/kstore.api
@@ -9,6 +9,10 @@ public final class io/github/xxfast/kstore/KStore {
 	public final fun update (Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
+public final class io/github/xxfast/kstore/extensions/KCachedStoreKt {
+	public static final fun getCached (Lio/github/xxfast/kstore/KStore;)Ljava/lang/Object;
+}
+
 public final class io/github/xxfast/kstore/extensions/KListStoreKt {
 	public static final fun get (Lio/github/xxfast/kstore/KStore;ILkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static final fun getOrEmpty (Lio/github/xxfast/kstore/KStore;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;

--- a/kstore/src/commonMain/kotlin/io/github/xxfast/kstore/extensions/KCachedStore.kt
+++ b/kstore/src/commonMain/kotlin/io/github/xxfast/kstore/extensions/KCachedStore.kt
@@ -1,0 +1,15 @@
+package io.github.xxfast.kstore.extensions
+
+import io.github.xxfast.kstore.KStore
+import io.github.xxfast.kstore.utils.ExperimentalKStoreApi
+import kotlinx.serialization.Serializable
+
+/**
+ * Get the cached value synchronously.
+ * Note: This value will be set even when the store's [KStore.enableCache] is set to false.
+ * Note: This value can be null if
+ *   1. no previous calls to [KStore.get]
+ *   2. there's no active subscriber to [KStore.updates]
+ */
+@ExperimentalKStoreApi
+val <T: @Serializable Any> KStore<T>.cached: T? get() = cache.value

--- a/kstore/src/commonMain/kotlin/io/github/xxfast/kstore/utils/ExperimentalKStoreApi.kt
+++ b/kstore/src/commonMain/kotlin/io/github/xxfast/kstore/utils/ExperimentalKStoreApi.kt
@@ -5,5 +5,5 @@ package io.github.xxfast.kstore.utils
  */
 @RequiresOptIn(message = "This API is experimental. It may be changed in the future without notice.")
 @Retention(AnnotationRetention.BINARY)
-@Target(AnnotationTarget.CLASS, AnnotationTarget.FUNCTION)
+@Target(AnnotationTarget.CLASS, AnnotationTarget.FUNCTION, AnnotationTarget.PROPERTY)
 annotation class ExperimentalKStoreApi

--- a/kstore/src/commonTest/kotlin/io/github/xxfast/kstore/extensions/KCachedStoreTests.kt
+++ b/kstore/src/commonTest/kotlin/io/github/xxfast/kstore/extensions/KCachedStoreTests.kt
@@ -1,0 +1,57 @@
+package io.github.xxfast.kstore.extensions
+
+import io.github.xxfast.kstore.Cat
+import io.github.xxfast.kstore.KStore
+import io.github.xxfast.kstore.MYLO
+import io.github.xxfast.kstore.storeOf
+import io.github.xxfast.kstore.utils.ExperimentalKStoreApi
+import io.github.xxfast.kstore.utils.FILE_SYSTEM
+import kotlinx.coroutines.test.runTest
+import okio.Path.Companion.toPath
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+@OptIn(ExperimentalKStoreApi::class)
+class KCachedStoreTests {
+  private val filePath: String = "test_cached.json"
+  private val store: KStore<Cat> = storeOf(filePath)
+
+  @AfterTest
+  fun setup() {
+    FILE_SYSTEM.delete(filePath.toPath())
+  }
+
+  @Test
+  fun testCachedEmpty() = runTest {
+    val expect: Cat? = null
+    val actual: Cat? = store.cached
+    assertEquals(expect, actual)
+  }
+
+  @Test
+  fun testCachedNotEmpty() = runTest {
+    store.set(MYLO)
+    val expect: Cat = MYLO
+    val actual: Cat? = store.cached
+    assertEquals(expect, actual)
+  }
+
+  @Test
+  fun testCachedWhenCacheDisabled() = runTest {
+    val nonCachingStore: KStore<Cat> = storeOf(enableCache = false, filePath = filePath)
+    nonCachingStore.set(MYLO)
+    val expect: Cat = MYLO
+    val actual: Cat? = nonCachingStore.cached
+    assertEquals(expect, actual)
+  }
+
+  @Test
+  fun testCachedCleared() = runTest {
+    store.set(MYLO)
+    store.delete()
+    val expect: Cat? = null
+    val actual: Cat? = store.cached
+    assertEquals(expect, actual)
+  }
+}


### PR DESCRIPTION
Addresses #12 

Usage of this can be a little confusing, hence marking this `@ExperimentalKStoreApi` for now. I might even change the `KStore.enableCache` to `KStore.readFromCache` to make this use-case more clearer in the future