### PR TITLE
Refactor move exception handling to the decoder

### DIFF
--- a/kstore/src/commonMain/kotlin/io/github/xxfast/kstore/extensions/KVersionedStore.kt
+++ b/kstore/src/commonMain/kotlin/io/github/xxfast/kstore/extensions/KVersionedStore.kt
@@ -7,6 +7,7 @@ import kotlinx.serialization.Serializable
 import kotlinx.serialization.SerializationException
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonElement
+import okio.FileNotFoundException
 import okio.Path
 import okio.Path.Companion.toPath
 import okio.buffer
@@ -53,13 +54,13 @@ public inline fun <reified T : @Serializable Any> storeOf(
       serializer.decode(FILE_SYSTEM.source(dataPath).buffer())
     } catch (e: SerializationException) {
       val previousVersion: Int =
-        if (FILE_SYSTEM.exists(versionPath))
-          serializer.decode(FILE_SYSTEM.source(versionPath).buffer())
-        else
-          0
+        if (FILE_SYSTEM.exists(versionPath)) serializer.decode(FILE_SYSTEM.source(versionPath).buffer())
+        else 0
 
       val data: JsonElement = serializer.decode(FILE_SYSTEM.source(dataPath).buffer())
       migration(previousVersion, data)
+    } catch (e: FileNotFoundException) {
+      default
     }
   }
 

--- a/kstore/src/commonTest/kotlin/io/github/xxfast/kstore/KVersionedStoreTests.kt
+++ b/kstore/src/commonTest/kotlin/io/github/xxfast/kstore/KVersionedStoreTests.kt
@@ -1,5 +1,6 @@
 package io.github.xxfast.kstore
 
+import io.github.xxfast.kstore.extensions.storeOf
 import io.github.xxfast.kstore.utils.FILE_SYSTEM
 import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.Serializable
@@ -27,10 +28,9 @@ class KVersionedStoreTests {
 
   private val storeV0: KStore<CatV0> = storeOf(filePath = filePath)
 
-  private val storeV1: KStore<CatV1> =
-    io.github.xxfast.kstore.extensions.storeOf(filePath = filePath, version = 1)
+  private val storeV1: KStore<CatV1> = storeOf(filePath = filePath, version = 1)
 
-  private val storeV2: KStore<CatV2> = io.github.xxfast.kstore.extensions.storeOf(
+  private val storeV2: KStore<CatV2> = storeOf(
     filePath = filePath,
     version = 2
   ) { version, jsonElement ->
@@ -47,7 +47,7 @@ class KVersionedStoreTests {
     }
   }
 
-  private val storeV3: KStore<CatV3> = io.github.xxfast.kstore.extensions.storeOf(
+  private val storeV3: KStore<CatV3> = storeOf(
     filePath = filePath,
     version = 3
   ) { version, jsonElement ->


### PR DESCRIPTION
Previously, decoding a malformed file will return the default. This behaviour is not always desirable and might be unexpected. Hence, I'm no longer making this behaviour the default.

With this change, the default decoder of `storeOf()` will throw if the file is malformed. To handle this, you'll need to implement your own safe decoder, depending on the behaviour you want. See `VerstionStore.kt` for an example of a custom behaviour 