### PR TITLE
Refactor kstore-file api to remove string filePaths

### DIFF
--- a/kstore-file/api/android/kstore-file.api
+++ b/kstore-file/api/android/kstore-file.api
@@ -1,5 +1,5 @@
 public final class io/github/xxfast/kstore/file/FileCodec : io/github/xxfast/kstore/Codec {
-	public fun <init> (Ljava/lang/String;Lkotlinx/serialization/json/Json;Lkotlinx/serialization/KSerializer;)V
+	public fun <init> (Lokio/Path;Lkotlinx/serialization/json/Json;Lkotlinx/serialization/KSerializer;)V
 	public fun decode (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun encode (Ljava/lang/Object;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
@@ -9,8 +9,8 @@ public final class io/github/xxfast/kstore/file/extensions/KVersionedStoreKt {
 }
 
 public final class io/github/xxfast/kstore/file/extensions/VersionedCodec : io/github/xxfast/kstore/Codec {
-	public fun <init> (Ljava/lang/String;ILkotlinx/serialization/json/Json;Lkotlinx/serialization/KSerializer;Lkotlin/jvm/functions/Function2;)V
-	public synthetic fun <init> (Ljava/lang/String;ILkotlinx/serialization/json/Json;Lkotlinx/serialization/KSerializer;Lkotlin/jvm/functions/Function2;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Lokio/Path;ILkotlinx/serialization/json/Json;Lkotlinx/serialization/KSerializer;Lkotlin/jvm/functions/Function2;)V
+	public synthetic fun <init> (Lokio/Path;ILkotlinx/serialization/json/Json;Lkotlinx/serialization/KSerializer;Lkotlin/jvm/functions/Function2;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun decode (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun encode (Ljava/lang/Object;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }

--- a/kstore-file/api/desktop/kstore-file.api
+++ b/kstore-file/api/desktop/kstore-file.api
@@ -1,5 +1,5 @@
 public final class io/github/xxfast/kstore/file/FileCodec : io/github/xxfast/kstore/Codec {
-	public fun <init> (Ljava/lang/String;Lkotlinx/serialization/json/Json;Lkotlinx/serialization/KSerializer;)V
+	public fun <init> (Lokio/Path;Lkotlinx/serialization/json/Json;Lkotlinx/serialization/KSerializer;)V
 	public fun decode (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun encode (Ljava/lang/Object;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
@@ -9,8 +9,8 @@ public final class io/github/xxfast/kstore/file/extensions/KVersionedStoreKt {
 }
 
 public final class io/github/xxfast/kstore/file/extensions/VersionedCodec : io/github/xxfast/kstore/Codec {
-	public fun <init> (Ljava/lang/String;ILkotlinx/serialization/json/Json;Lkotlinx/serialization/KSerializer;Lkotlin/jvm/functions/Function2;)V
-	public synthetic fun <init> (Ljava/lang/String;ILkotlinx/serialization/json/Json;Lkotlinx/serialization/KSerializer;Lkotlin/jvm/functions/Function2;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Lokio/Path;ILkotlinx/serialization/json/Json;Lkotlinx/serialization/KSerializer;Lkotlin/jvm/functions/Function2;)V
+	public synthetic fun <init> (Lokio/Path;ILkotlinx/serialization/json/Json;Lkotlinx/serialization/KSerializer;Lkotlin/jvm/functions/Function2;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun decode (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun encode (Ljava/lang/Object;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }

--- a/kstore-file/build.gradle.kts
+++ b/kstore-file/build.gradle.kts
@@ -88,7 +88,7 @@ kotlin {
       val commonMain by getting {
         dependencies {
           implementation(project(":kstore"))
-          implementation(libs.okio)
+          api(libs.okio)
           implementation(libs.kotlinx.coroutines)
           implementation(libs.kotlinx.serialization.json)
           implementation(libs.kotlinx.serialization.json.okio)

--- a/kstore-file/src/commonMain/kotlin/io/github/xxfast/kstore/file/KStore.kt
+++ b/kstore-file/src/commonMain/kotlin/io/github/xxfast/kstore/file/KStore.kt
@@ -4,11 +4,12 @@ import io.github.xxfast.kstore.DefaultJson
 import io.github.xxfast.kstore.KStore
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
+import okio.Path
 
 /**
  * Creates a store with [FileCodec]
  *
- * @param filePath path to the file that is managed by this store
+ * @param file path to the file that is managed by this store
  * @param default returns this value if the file is not found. defaults to null
  * @param enableCache maintain a cache. If set to false, it always reads from disk
  * @param json Serializer to use. defaults to [DefaultJson]
@@ -16,12 +17,12 @@ import kotlinx.serialization.json.Json
  * @return store that contains a value of type [T]
  */
 public inline fun <reified T : @Serializable Any> storeOf(
-  filePath: String,
+  file: Path,
   default: T? = null,
   enableCache: Boolean = true,
   json: Json = DefaultJson,
 ): KStore<T> = KStore(
   default = default,
   enableCache = enableCache,
-  codec = FileCodec(filePath, json)
+  codec = FileCodec(file, json)
 )

--- a/kstore-file/src/commonMain/kotlin/io/github/xxfast/kstore/file/extensions/KListStore.kt
+++ b/kstore-file/src/commonMain/kotlin/io/github/xxfast/kstore/file/extensions/KListStore.kt
@@ -6,11 +6,12 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
+import okio.Path
 
 /**
  * Creates a store that contains a list
  *
- * @param filePath path to the file that is managed by this store
+ * @param file path to the file that is managed by this store
  * @param default returns this value if the file is not found. defaults to empty list
  * @param enableCache maintain a cache. If set to false, it always reads from disk
  * @param json Serializer to use. Defaults serializer ignores unknown keys and encodes the defaults
@@ -18,9 +19,9 @@ import kotlinx.serialization.json.Json
  * @return store that contains a list of type [T]
  */
 public inline fun <reified T : @Serializable Any> listStoreOf(
-  filePath: String,
+  file: Path,
   default: List<T> = emptyList(),
   enableCache: Boolean = true,
   json: Json = Json { ignoreUnknownKeys = true; encodeDefaults = true },
 ): KStore<List<T>> =
-  storeOf(filePath, default, enableCache, json)
+  storeOf(file, default, enableCache, json)

--- a/kstore-file/src/commonTest/kotlin/io/github/xxfast/kstore/file/FileCodecTests.kt
+++ b/kstore-file/src/commonTest/kotlin/io/github/xxfast/kstore/file/FileCodecTests.kt
@@ -8,27 +8,24 @@ import kotlinx.serialization.SerializationException
 import okio.Path.Companion.toPath
 import okio.buffer
 import okio.use
-import kotlin.test.AfterTest
-import kotlin.test.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertFailsWith
+import kotlin.test.*
 
 import kotlinx.serialization.json.okio.decodeFromBufferedSource as decode
 import kotlinx.serialization.json.okio.encodeToBufferedSink as decode
 
 class FileCodecTests {
-  private val codec: FileCodec<Cat> = FileCodec(filePath = FILE)
+  private val codec: FileCodec<Cat> = FileCodec(file = FILE_PATH.toPath())
 
   @OptIn(ExperimentalSerializationApi::class)
   private var stored: Cat?
-    get() = FILE_SYSTEM.source(FILE.toPath()).buffer().use { DefaultJson.decode(it) }
+    get() = FILE_SYSTEM.source(FILE_PATH.toPath()).buffer().use { DefaultJson.decode(it) }
     set(value) {
-      FILE_SYSTEM.sink(FILE.toPath()).buffer().use { DefaultJson.decode(value, it) }
+      FILE_SYSTEM.sink(FILE_PATH.toPath()).buffer().use { DefaultJson.decode(value, it) }
     }
 
   @AfterTest
   fun cleanUp() {
-    FILE_SYSTEM.delete(FILE.toPath())
+    FILE_SYSTEM.delete(FILE_PATH.toPath())
   }
 
   @Test
@@ -48,17 +45,8 @@ class FileCodecTests {
   }
 
   @Test
-  fun testEncodeDecodeFromDirectory() = runTest {
-    val dirCodec: FileCodec<Cat> = FileCodec(filePath = "$FOLDER/$FILE")
-    dirCodec.encode(MYLO)
-    val expect: Pet = MYLO
-    val actual: Pet? = dirCodec.decode()
-    assertEquals(expect, actual)
-  }
-
-  @Test
   fun testDecodeMalformedFile() = runTest {
-    FILE_SYSTEM.sink(FILE.toPath()).buffer().use { it.writeUtf8("💩") }
+    FILE_SYSTEM.sink(FILE_PATH.toPath()).buffer().use { it.writeUtf8("💩") }
     assertFailsWith<SerializationException> { codec.decode() }
   }
 }

--- a/kstore-file/src/commonTest/kotlin/io/github/xxfast/kstore/file/TestModels.kt
+++ b/kstore-file/src/commonTest/kotlin/io/github/xxfast/kstore/file/TestModels.kt
@@ -18,5 +18,4 @@ data class Cat(
 internal val MYLO = Cat(name = "Mylo", age = 1)
 internal val OREO = Cat(name = "Oreo", age = 1)
 
-const val FILE = "test.json"
-const val FOLDER = "build/bin/tests"
+const val FILE_PATH = "test.json"

--- a/kstore-file/src/commonTest/kotlin/io/github/xxfast/kstore/file/extensions/KListStoreTests.kt
+++ b/kstore-file/src/commonTest/kotlin/io/github/xxfast/kstore/file/extensions/KListStoreTests.kt
@@ -20,6 +20,7 @@ import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.okio.encodeToBufferedSink
+import okio.Path
 import okio.Path.Companion.toPath
 import okio.buffer
 import okio.use
@@ -28,12 +29,12 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 
 class KListStoreTests {
-  private val filePath: String = "test_lists.json"
-  private val store: KStore<List<Cat>> = listStoreOf(filePath = filePath)
+  private val file: Path = "test_lists.json".toPath()
+  private val store: KStore<List<Cat>> = listStoreOf(file = file)
 
   @AfterTest
   fun setup() {
-    FILE_SYSTEM.delete(filePath.toPath())
+    FILE_SYSTEM.delete(file)
   }
 
   @Test
@@ -53,7 +54,7 @@ class KListStoreTests {
 
   @Test
   fun testReadDefault() = runTest {
-    val defaultStore: KStore<List<Cat>> = listStoreOf(filePath = filePath, default = listOf(MYLO))
+    val defaultStore: KStore<List<Cat>> = listStoreOf(file = file, default = listOf(MYLO))
     val expect: List<Cat> = listOf(MYLO)
     val actual: List<Cat> = defaultStore.getOrEmpty()
     assertEquals(expect, actual)
@@ -61,9 +62,9 @@ class KListStoreTests {
 
   @Test
   fun testReadPreviouslyStoredList() = runTest {
-    FILE_SYSTEM.sink(filePath.toPath()).buffer().use { Json.encodeToBufferedSink(listOf(OREO) , it) }
+    FILE_SYSTEM.sink(file).buffer().use { Json.encodeToBufferedSink(listOf(OREO) , it) }
     // Mylo will never be sent 😿 because there is already a stored value
-    val newStore: KStore<List<Cat>> = listStoreOf(filePath = filePath, default = listOf(MYLO))
+    val newStore: KStore<List<Cat>> = listStoreOf(file = file, default = listOf(MYLO))
     val expect: List<Cat> = listOf(OREO)
     val actual: List<Cat> = newStore.getOrEmpty()
     assertEquals(expect, actual)

--- a/kstore-file/src/commonTest/kotlin/io/github/xxfast/kstore/file/extensions/KVersionedStoreTests.kt
+++ b/kstore-file/src/commonTest/kotlin/io/github/xxfast/kstore/file/extensions/KVersionedStoreTests.kt
@@ -9,6 +9,7 @@ import kotlinx.serialization.json.int
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 import kotlinx.serialization.json.long
+import okio.Path
 import okio.Path.Companion.toPath
 import kotlin.test.AfterTest
 import kotlin.test.Test
@@ -25,14 +26,14 @@ val MYLO_V2 = CatV2(name = "mylo", lives = 7, age = 2, kawaiiness = 12L)
 val MYLO_V3 = CatV3(name = "mylo", lives = 7, age = 2, isCute = true)
 
 class KVersionedStoreTests {
-  private val filePath: String = "test_migration.json"
+  private val file: Path = "test_migration.json".toPath()
 
-  private val storeV0: KStore<CatV0> = storeOf(filePath = filePath)
+  private val storeV0: KStore<CatV0> = storeOf(file = file)
 
-  private val storeV1: KStore<CatV1> = storeOf(filePath = filePath, version = 1)
+  private val storeV1: KStore<CatV1> = storeOf(file = file, version = 1)
 
   private val storeV2: KStore<CatV2> = storeOf(
-    filePath = filePath,
+    file = file,
     version = 2
   ) { version, jsonElement ->
     when (version) {
@@ -49,7 +50,7 @@ class KVersionedStoreTests {
   }
 
   private val storeV3: KStore<CatV3> = storeOf(
-    filePath = filePath,
+    file = file,
     version = 3
   ) { version, jsonElement ->
     when (version) {
@@ -75,8 +76,8 @@ class KVersionedStoreTests {
 
   @AfterTest
   fun cleanup() {
-    FILE_SYSTEM.delete(filePath.toPath())
-    FILE_SYSTEM.delete("$filePath.version".toPath())
+    FILE_SYSTEM.delete(file)
+    FILE_SYSTEM.delete("${file.name}.version".toPath())
   }
 
   @Test


### PR DESCRIPTION
With this change, I'm shifting the responsibility of managing the file from the library to the user. 