### PR TITLE
Lock initial read in `onStart`

### DIFF
--- a/kstore/src/commonMain/kotlin/io/github/xxfast/kstore/KStore.kt
+++ b/kstore/src/commonMain/kotlin/io/github/xxfast/kstore/KStore.kt
@@ -28,7 +28,11 @@ public class KStore<T : @Serializable Any>(
   /** Observe store for updates */
   public val updates: Flow<T?>
     get() = this.cache
-      .onStart { read(fromCache = false) } // updates will always start with a fresh read
+      .onStart {
+        lock.withLock {
+          read(fromCache = false)
+        }
+      } // updates will always start with a fresh read
 
   private suspend fun write(value: T?): Unit = withContext(StoreDispatcher) {
     codec.encode(value)


### PR DESCRIPTION
The initial read in `file/KStore` isn't protected by the lock that writes and other reads are. This can lead to a case where an application triggers a write during the initial read, causing the read to get truncated data with larger file sizes.