### PR TITLE
Ensure version files are created at same path as store

### DIFF
--- a/kstore-file/api/android/kstore-file.api
+++ b/kstore-file/api/android/kstore-file.api
@@ -9,8 +9,8 @@ public final class io/github/xxfast/kstore/file/extensions/KVersionedStoreKt {
 }
 
 public final class io/github/xxfast/kstore/file/extensions/VersionedCodec : io/github/xxfast/kstore/Codec {
-	public fun <init> (Lokio/Path;ILkotlinx/serialization/json/Json;Lkotlinx/serialization/KSerializer;Lkotlin/jvm/functions/Function2;)V
-	public synthetic fun <init> (Lokio/Path;ILkotlinx/serialization/json/Json;Lkotlinx/serialization/KSerializer;Lkotlin/jvm/functions/Function2;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Lokio/Path;ILkotlinx/serialization/json/Json;Lkotlinx/serialization/KSerializer;Lkotlin/jvm/functions/Function2;Lokio/Path;)V
+	public synthetic fun <init> (Lokio/Path;ILkotlinx/serialization/json/Json;Lkotlinx/serialization/KSerializer;Lkotlin/jvm/functions/Function2;Lokio/Path;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun decode (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun encode (Ljava/lang/Object;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }

--- a/kstore-file/api/desktop/kstore-file.api
+++ b/kstore-file/api/desktop/kstore-file.api
@@ -9,8 +9,8 @@ public final class io/github/xxfast/kstore/file/extensions/KVersionedStoreKt {
 }
 
 public final class io/github/xxfast/kstore/file/extensions/VersionedCodec : io/github/xxfast/kstore/Codec {
-	public fun <init> (Lokio/Path;ILkotlinx/serialization/json/Json;Lkotlinx/serialization/KSerializer;Lkotlin/jvm/functions/Function2;)V
-	public synthetic fun <init> (Lokio/Path;ILkotlinx/serialization/json/Json;Lkotlinx/serialization/KSerializer;Lkotlin/jvm/functions/Function2;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Lokio/Path;ILkotlinx/serialization/json/Json;Lkotlinx/serialization/KSerializer;Lkotlin/jvm/functions/Function2;Lokio/Path;)V
+	public synthetic fun <init> (Lokio/Path;ILkotlinx/serialization/json/Json;Lkotlinx/serialization/KSerializer;Lkotlin/jvm/functions/Function2;Lokio/Path;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun decode (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun encode (Ljava/lang/Object;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }


### PR DESCRIPTION
Addresses #99

I did not have the time yet to verify the result. However, these changes should pretty much ensure that the version file will always be created at the same location as the store itself, having the ".version" suffix.
Therefore, if the targeted directory is write-accessable on android, there shall be no more errors during the creation of such versioned stores.