### PR TITLE
[Issue-85] Reuse KStore instance if the same codec is provided

### DIFF
--- a/kstore-file/src/commonMain/kotlin/io/github/xxfast/kstore/file/FileCodec.kt
+++ b/kstore-file/src/commonMain/kotlin/io/github/xxfast/kstore/file/FileCodec.kt
@@ -75,4 +75,8 @@ public class FileCodec<T : @Serializable Any>(
 
     SystemFileSystem.atomicMove(source = tempFile, destination = file)
   }
+
+  override fun id(): Any {
+    return this.file.toString() + this.serializer.descriptor.serialName
+  }
 }

--- a/kstore-storage/src/commonMain/kotlin/io/github/xxfast/kstore/storage/StorageCodec.kt
+++ b/kstore-storage/src/commonMain/kotlin/io/github/xxfast/kstore/storage/StorageCodec.kt
@@ -31,4 +31,8 @@ public class StorageCodec<T : @Serializable Any>(
 
   override suspend fun decode(): T? = storage[key]
     ?.let { format.decodeFromString(serializer, it) }
+
+  override fun id(): Any {
+    return storage.toString() + serializer.descriptor.serialName
+  }
 }

--- a/kstore/src/commonMain/kotlin/io/github/xxfast/kstore/Codec.kt
+++ b/kstore/src/commonMain/kotlin/io/github/xxfast/kstore/Codec.kt
@@ -17,4 +17,10 @@ public interface Codec<T: @Serializable Any> {
    * @return optional value that is decoded
    */
   public suspend fun decode(): T?
+
+  /**
+   * Tells the store factory whether to create a new store or reuse an existing one.
+   * @return the id of the codec.
+   */
+  public fun id(): Any = this
 }

--- a/kstore/src/commonMain/kotlin/io/github/xxfast/kstore/KStore.kt
+++ b/kstore/src/commonMain/kotlin/io/github/xxfast/kstore/KStore.kt
@@ -18,15 +18,22 @@ import kotlinx.serialization.Serializable
  *
  * @return store that contains a value of type [T]
  */
-public inline fun <reified T : @Serializable Any> storeOf(
+public fun <T : @Serializable Any> storeOf(
   codec: Codec<T>,
   default: T? = null,
   enableCache: Boolean = true,
-): KStore<T> = KStore(
-  default = default,
-  enableCache = enableCache,
-  codec = codec
-)
+): KStore<T> {
+  return KStoreFactory.getOrCreate(
+    key = codec,
+    creator = {
+      KStore(
+        default = default,
+        enableCache = enableCache,
+        codec = codec
+      )
+    }
+  )
+}
 
 /**
  * Creates a store with a custom encoder and a decoder
@@ -109,5 +116,6 @@ public class KStore<T : @Serializable Any>(
 
   override fun close() {
     if (lock.isLocked) lock.unlock()
+    KStoreFactory.release(key = codec)
   }
 }

--- a/kstore/src/commonMain/kotlin/io/github/xxfast/kstore/KStoreFactory.kt
+++ b/kstore/src/commonMain/kotlin/io/github/xxfast/kstore/KStoreFactory.kt
@@ -1,0 +1,46 @@
+package io.github.xxfast.kstore
+
+/**
+ * A factory for reusing and managing KStore instances keyed by an arbitrary identity (e.g., file path).
+ */
+internal object KStoreFactory {
+  private val storeMap: MutableMap<Any, KStore<*>> = mutableMapOf()
+  private val referenceCountMap: MutableMap<Any, Int> = mutableMapOf()
+
+  /**
+   * Get or create a `KStore<T>` for the given key.
+   * Ensures that only one instance exists per key.
+   *
+   * @param key Unique identity to associate the store with (e.g., file path or custom string).
+   * @param creator Lambda to create a new store if one doesn't exist for the key.
+   */
+  @Suppress("UNCHECKED_CAST")
+  internal fun <T : Any> getOrCreate(
+    key: Any,
+    creator: () -> KStore<T>
+  ): KStore<T> {
+    referenceCountMap[key] = referenceCountMap.getOrElse(key, { 0 }) + 1
+
+    val existing = storeMap[key]
+    if (existing != null) {
+      return existing as KStore<T>
+    }
+
+    val created = creator()
+    storeMap[key] = created
+    return created
+  }
+
+  /**
+   * Explicitly remove a store instance for a key (e.g., to free memory).
+   */
+  internal fun release(key: Any)  {
+    val referenceCount = referenceCountMap.getOrElse(key, { 0 })
+    if (referenceCount <= 1) {
+      storeMap.remove(key)
+      referenceCountMap.remove(key)
+    } else {
+      referenceCountMap[key] = referenceCount - 1
+    }
+  }
+}


### PR DESCRIPTION
https://github.com/xxfast/KStore/issues/85

`When you create multiple stores pointing to the same file, those stores will not know about the updates from each other and can cause stores to be out of sync.`

I am thinking that we can use Factory pattern here. 
When creating the instances of KStore, we check first if any instance exists for the provided codec. If yes, we can use the existing instance, otherwise we create a new instance and store it in a map.