### PR TITLE
kotlin 2.x : move to default hierarchy template (fixes: #152)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -26,7 +26,7 @@ allprojects {
   }
 
   group = "io.github.xxfast"
-  version = "1.0.0"
+  version = "2.0.0"
 
   apply(plugin = "org.jetbrains.kotlin.plugin.serialization")
   apply(plugin = "org.jetbrains.kotlinx.kover")
@@ -53,7 +53,7 @@ allprojects {
     val javadocJar = tasks.register<Jar>("javadocJar") {
       dependsOn(tasks.dokkaHtml)
       archiveClassifier.set("javadoc")
-      from("$buildDir/dokka")
+      from("${layout.buildDirectory}/dokka")
     }
 
     publications {

--- a/kstore-file/build.gradle.kts
+++ b/kstore-file/build.gradle.kts
@@ -1,45 +1,14 @@
 plugins {
   kotlin("multiplatform")
-  id("com.android.library")
   id("org.jetbrains.kotlinx.binary-compatibility-validator") version "0.17.0"
-}
-
-android {
-  compileSdk = 36
-
-  defaultConfig {
-    minSdk = 21
-  }
-
-  sourceSets["main"].manifest.srcFile("src/androidMain/AndroidManifest.xml")
-
-  compileOptions {
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
-  }
-
-  lint {
-    // TODO: Figure out why the linter is failing on CI
-    abortOnError = false
-  }
-
-  namespace = "io.github.xxfast.kstore.file"
 }
 
 kotlin {
   explicitApi()
 
-  androidTarget {
-    compilations.all {
-      kotlinOptions {
-        jvmTarget = "1.8"
-      }
-    }
-  }
-
-  jvm("desktop") {
-    compilations.all {
-      kotlinOptions.jvmTarget = "1.8"
+  jvm {
+    compilerOptions {
+      jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_1_8)
     }
     testRuns["test"].executionTask.configure {
       useJUnitPlatform()
@@ -50,25 +19,15 @@ kotlin {
     nodejs()
   }
 
-  val macosX64 = macosX64()
-  val macosArm64 = macosArm64()
-  val iosArm64 = iosArm64()
-  val iosX64 = iosX64()
-  val iosSimulatorArm64 = iosSimulatorArm64()
-  val watchosArm32 = watchosArm32()
-  val watchosArm64 = watchosArm64()
-  val watchosX64 = watchosX64()
-  val watchosSimulatorArm64 = watchosSimulatorArm64()
-  val tvosArm64 = tvosArm64()
-  val tvosX64 = tvosX64()
-  val tvosSimulatorArm64 = tvosSimulatorArm64()
+
   val appleTargets = listOf(
-    macosX64, macosArm64,
-    iosArm64, iosX64, iosSimulatorArm64,
-    watchosArm32, watchosArm64, watchosX64,
-    watchosSimulatorArm64,
-    tvosArm64, tvosX64, tvosSimulatorArm64,
+    macosX64(), macosArm64(),
+    iosArm64(), iosX64(), iosSimulatorArm64(),
+    watchosArm32(), watchosArm64(), watchosX64(),
+    watchosSimulatorArm64(),
+    tvosArm64(), tvosX64(), tvosSimulatorArm64(),
   )
+
 
   appleTargets.forEach { target ->
     with(target) {
@@ -80,12 +39,15 @@ kotlin {
     }
   }
 
-  linuxX64("linux")
-  mingwX64("windows")
+  linuxX64()
+  linuxArm64()
+  mingwX64()
+
+  applyDefaultHierarchyTemplate()
 
   sourceSets {
     sourceSets {
-      val commonMain by getting {
+      commonMain {
         dependencies {
           implementation(project(":kstore"))
           api(libs.kotlinx.io)
@@ -94,48 +56,13 @@ kotlin {
         }
       }
 
-      val commonTest by getting {
+      commonTest {
         dependencies {
           implementation(kotlin("test"))
           implementation(libs.kotlinx.coroutines.test)
           implementation(libs.turbine)
         }
       }
-
-      val androidMain by getting
-      val androidUnitTest by getting
-
-      val desktopMain by getting {
-        dependencies {
-        }
-      }
-      val desktopTest by getting
-
-      val jsMain by getting
-
-      val jsTest by getting
-
-      val appleMain by creating {
-        dependsOn(commonMain)
-      }
-      val appleTest by creating
-
-      appleTargets.forEach { target ->
-        getByName("${target.targetName}Main") { dependsOn(appleMain) }
-        getByName("${target.targetName}Test") { dependsOn(appleTest) }
-      }
-
-      val linuxMain by getting {
-        dependencies {
-        }
-      }
-      val linuxTest by getting
-
-      val windowsMain by getting {
-        dependencies {
-        }
-      }
-      val windowsTest by getting
     }
   }
 }

--- a/kstore-storage/build.gradle.kts
+++ b/kstore-storage/build.gradle.kts
@@ -1,3 +1,4 @@
+import org.jetbrains.kotlin.gradle.ExperimentalWasmDsl
 import org.jetbrains.kotlin.gradle.targets.js.nodejs.NodeJsRootExtension
 import org.jetbrains.kotlin.gradle.targets.js.npm.tasks.KotlinNpmInstallTask
 
@@ -13,26 +14,27 @@ kotlin {
     browser()
   }
 
+  @OptIn(ExperimentalWasmDsl::class)
   wasmJs {
     binaries.executable()
     browser()
   }
 
   sourceSets {
-    val commonMain by getting {
+    commonMain {
       dependencies {
         implementation(project(":kstore"))
         implementation(libs.kotlinx.serialization.json)
       }
     }
 
-    val wasmJsMain by getting {
+    wasmJsMain {
       dependencies {
         implementation(libs.kotlinx.browser)
       }
     }
 
-    val commonTest by getting {
+    commonTest {
       dependencies {
         implementation(kotlin("test"))
         implementation(libs.kotlinx.coroutines.test)

--- a/kstore/build.gradle.kts
+++ b/kstore/build.gradle.kts
@@ -1,54 +1,25 @@
-import org.jetbrains.kotlin.gradle.targets.js.dsl.ExperimentalWasmDsl
+import org.jetbrains.kotlin.gradle.ExperimentalWasmDsl
 import org.jetbrains.kotlin.gradle.targets.js.nodejs.NodeJsRootExtension
 import org.jetbrains.kotlin.gradle.targets.js.npm.tasks.KotlinNpmInstallTask
 
 plugins {
   kotlin("multiplatform")
-  id("com.android.library")
   id("org.jetbrains.kotlinx.binary-compatibility-validator") version "0.17.0"
 }
 
-android {
-  compileSdk = 36
-
-  defaultConfig {
-    minSdk = 21
-  }
-
-  sourceSets["main"].manifest.srcFile("src/androidMain/AndroidManifest.xml")
-
-  compileOptions {
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
-  }
-
-  lint {
-    // TODO: Figure out why the linter is failing on CI
-    abortOnError = false
-  }
-
-  namespace = "io.github.xxfast.kstore"
-}
 
 kotlin {
   explicitApi()
 
-  androidTarget {
-    compilations.all {
-      kotlinOptions {
-        jvmTarget = "1.8"
-      }
-    }
-  }
-
-  jvm("desktop") {
-    compilations.all {
-      kotlinOptions.jvmTarget = "1.8"
+  jvm {
+    compilerOptions {
+      jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_1_8)
     }
     testRuns["test"].executionTask.configure {
       useJUnitPlatform()
     }
   }
+
 
   js(IR) {
     browser()
@@ -61,24 +32,12 @@ kotlin {
     nodejs()
   }
 
-  val macosX64 = macosX64()
-  val macosArm64 = macosArm64()
-  val iosArm64 = iosArm64()
-  val iosX64 = iosX64()
-  val iosSimulatorArm64 = iosSimulatorArm64()
-  val watchosArm32 = watchosArm32()
-  val watchosArm64 = watchosArm64()
-  val watchosX64 = watchosX64()
-  val watchosSimulatorArm64 = watchosSimulatorArm64()
-  val tvosArm64 = tvosArm64()
-  val tvosX64 = tvosX64()
-  val tvosSimulatorArm64 = tvosSimulatorArm64()
   val appleTargets = listOf(
-    macosX64, macosArm64,
-    iosArm64, iosX64, iosSimulatorArm64,
-    watchosArm32, watchosArm64, watchosX64,
-    watchosSimulatorArm64,
-    tvosArm64, tvosX64, tvosSimulatorArm64,
+    macosX64(), macosArm64(),
+    iosArm64(), iosX64(), iosSimulatorArm64(),
+    watchosArm32(), watchosArm64(), watchosX64(),
+    watchosSimulatorArm64(),
+    tvosArm64(), tvosX64(), tvosSimulatorArm64(),
   )
 
   appleTargets.forEach { target ->
@@ -91,18 +50,21 @@ kotlin {
     }
   }
 
-  linuxX64("linux")
-  mingwX64("windows")
+  linuxX64()
+  linuxArm64()
+  mingwX64()
+
+  applyDefaultHierarchyTemplate()
 
   sourceSets {
-    val commonMain by getting {
+    commonMain {
       dependencies {
         implementation(libs.kotlinx.coroutines)
         implementation(libs.kotlinx.serialization.json)
       }
     }
 
-    val commonTest by getting {
+    commonTest {
       dependencies {
         implementation(kotlin("test"))
         implementation(libs.kotlinx.coroutines.test)
@@ -110,40 +72,13 @@ kotlin {
       }
     }
 
-    val androidMain by getting
-    val androidUnitTest by getting {
+    jvmTest {
       dependencies {
         implementation(libs.junit)
         implementation(libs.junit.jupiter.api)
         implementation(libs.junit.jupiter.engine)
-        implementation(libs.androidx.test.junit)
       }
     }
-
-    val desktopMain by getting
-    val desktopTest by getting
-
-    val jsMain by getting
-    val jsTest by getting
-
-    val wasmJsMain by getting
-    val wasmJsTest by getting
-
-    val appleMain by creating {
-      dependsOn(commonMain)
-    }
-    val appleTest by creating
-
-    appleTargets.forEach { target ->
-      getByName("${target.targetName}Main") { dependsOn(appleMain) }
-      getByName("${target.targetName}Test") { dependsOn(appleTest) }
-    }
-
-    val linuxMain by getting
-    val linuxTest by getting
-
-    val windowsMain by getting
-    val windowsTest by getting
   }
 }
 


### PR DESCRIPTION
This fixes #152  

> NOTE: This bumps version to 2.0.0 because technically this is a breaking change as the dependency tree and hierarchy changes

- we product basically only jvm, native and js (wasm + normal) as libraries
- desktop compose apps will use jvm variant
- android will use jvm variant
- all apple targets will use native variant
- kotlin/native (cli apps) will use native variant too

none of this needs to be configured by apps consuming this library, this is handled automatically by default hierarchy template

instructions on how to use the library and installation steps do NOT change, it is still same except browser, everywhere else we use kstore-file on browser we use kstore-storage